### PR TITLE
Softdepend on WorldLoad

### DIFF
--- a/Holograms/src/main/resources/plugin.yml
+++ b/Holograms/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ description: ${project.description}
 author: SainttX
 
 main: com.sainttx.holograms.HologramPlugin
-softdepend: [ Multiverse-Core, MultiWorld ]
+softdepend: [ Multiverse-Core, MultiWorld, WorldLoad ]
 
 commands:
   holograms:


### PR DESCRIPTION
Prevent spawning holograms before worlds are loaded if additional worlds are loaded by [WorldLoad](https://www.spigotmc.org/resources/worldload.9812/)