### PR TITLE
getLines(): Return List instead of Collection

### DIFF
--- a/Holograms-API/src/main/java/com/sainttx/holograms/api/Hologram.java
+++ b/Holograms-API/src/main/java/com/sainttx/holograms/api/Hologram.java
@@ -8,7 +8,6 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 import java.beans.ConstructorProperties;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 public class Hologram {
@@ -107,7 +106,7 @@ public class Hologram {
      *
      * @return all lines in the hologram
      */
-    public Collection<HologramLine> getLines() {
+    public List<HologramLine> getLines() {
         return lines;
     }
 


### PR DESCRIPTION
The title says it all. Returning a list allows developers to better manipulate hologram lines.