### PR TITLE
Added base permission to holograms command.

### DIFF
--- a/Holograms/src/main/resources/plugin.yml
+++ b/Holograms/src/main/resources/plugin.yml
@@ -12,6 +12,7 @@ commands:
   holograms:
     description: All commands for Hologram
     aliases: [hologram, holo, h]
+    permission: holograms.base
     permission-message: You do not have sufficient permissions to use this command
 
 permissions:


### PR DESCRIPTION
Unfortunately, while using this plugin, I discovered that everyone can see the base hologram command, even when they don't have access to any of it's sub-commands. This is due to the fact that the base command doesn't have a permission for it, therefor, identifying the command as a "default access" command for everyone to use.

Though this is ONE fix for any number of possibilities of fixes for this issue, the purpose behind this change is to set a permission node for Bukkit to register to the base command, so that the command doesn't show on everyone's possible command list, even if they don't have permission for it.

If you could find a way to implement a change like this to your permissions tree to make it default to players who have sub-commands, or make it so that the negated "holograms.base" permission would register in Bukkit to not show the command to players who have the negated permission, that would be amazing! This would mean the difference between using this plugin or not, for me personally. But thank you for your time and consideration, and I hope you can figure something out. :)